### PR TITLE
Publish initial packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "public",
+  "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/rare-plants-itch.md
+++ b/.changeset/rare-plants-itch.md
@@ -1,6 +1,6 @@
 ---
-'@nl-design-system-community/editor': minor
-'@nl-design-system-community/editor-react': minor
+'@nl-design-system-community/editor': major
+'@nl-design-system-community/editor-react': major
 ---
 
-Initial alpha release of `@nl-design-system-community/editor` and `@nl-design-system-community/editor-react`.
+Initial npm release of package

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -5,7 +5,10 @@
     "url": "https://github.com/nl-design-system/editor.git",
     "directory": "packages/editor"
   },
-  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "version": "0.0.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,7 +5,10 @@
     "url": "https://github.com/nl-design-system/editor.git",
     "directory": "packages/react"
   },
-  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "version": "0.0.0",
   "type": "module",
   "files": [


### PR DESCRIPTION
- Playwright report is not readable in github directly, so it is removed
- The to public, as it runs into npm publish private issues
- Create changeset for editor and editor-react