### PR TITLE
ci: explicitly define registry, and hopefully login

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          registry-url: "https://registry.npmjs.org"
 
       - name: Set up Node.js version and cache
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0


### PR DESCRIPTION
Dit stond al [in de voorbeelden](https://docs.npmjs.com/trusted-publishers#supported-cicd-providers), maar ik hoopte het niet nodig te hebben omdat het overeenkomt met de registry die we al in gebruiken. Maar misschien triggert dit `npm login` en voorkomt het de foutmelding: https://github.com/nl-design-system/editor/actions/runs/18747993669/job/53479919728#step:7:32