### PR TITLE
fix: externalize react deps

### DIFF
--- a/.changeset/yellow-numbers-go.md
+++ b/.changeset/yellow-numbers-go.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-community/editor-react': patch
+---
+
+Fix: Add globals to rollup options for ssr react conflict

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -7,6 +7,15 @@ export default defineConfig({
       fileName: 'index',
       formats: ['es'],
     },
+    rollupOptions: {
+      external: ['react', 'react-dom'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
+      },
+    },
   },
   server: {
     port: 5175,


### PR DESCRIPTION
Ik heb dit gereproduceerd met `pnpm serve` in de documentation repo. `pnpm dev` werkte prima. Iets met ssr/hydration. Ik heb deze fix lokaal getest door een lokaal gebuilde en gepackte `editor-react` package te installeren in de documentation repo, en deze vervolgens opnieuw te builden en serven. Het probleem was daarmee lokaal verholpen.