### PR TITLE
build: add npm keyword for expertteam-digitale-toegankelijkheid

### DIFF
--- a/.changeset/cool-beers-cry.md
+++ b/.changeset/cool-beers-cry.md
@@ -1,0 +1,7 @@
+---
+'@nl-design-system-community/editor-website': patch
+'@nl-design-system-community/editor': patch
+'@nl-design-system-community/editor-react': patch
+---
+
+Add `expertteam-digitale-toegankelijkheid` keyword to npm packages.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Design system based on the NL Design System architecture",
   "license": "EUPL-1.2",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,

--- a/packages/editor-website/package.json
+++ b/packages/editor-website/package.json
@@ -5,6 +5,10 @@
     "url": "https://github.com/nl-design-system/editor.git",
     "directory": "packages/editor-website"
   },
+  "keywords": [
+    "expertteam-digitale-toegankelijkheid",
+    "nl-design-system"
+  ],
   "private": true,
   "version": "0.0.5",
   "type": "module",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -5,6 +5,10 @@
     "url": "https://github.com/nl-design-system/editor.git",
     "directory": "packages/editor"
   },
+  "keywords": [
+    "expertteam-digitale-toegankelijkheid",
+    "nl-design-system"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -5,6 +5,10 @@
     "url": "https://github.com/nl-design-system/editor.git",
     "directory": "packages/react"
   },
+  "keywords": [
+    "expertteam-digitale-toegankelijkheid",
+    "nl-design-system"
+  ],
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/proprietary/assets/package.json
+++ b/proprietary/assets/package.json
@@ -5,6 +5,7 @@
   "description": "Assets",
   "license": "SEE LICENSE IN LICENSE.md",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,

--- a/proprietary/design-tokens/package.json
+++ b/proprietary/design-tokens/package.json
@@ -5,6 +5,7 @@
   "description": "Example design tokens",
   "license": "SEE LICENSE IN LICENSE.md",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,

--- a/proprietary/font/package.json
+++ b/proprietary/font/package.json
@@ -6,6 +6,7 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "dist/index.css",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,


### PR DESCRIPTION
Even een keyword toegevoegd zodat we makkelijk een overzicht van onze packages maken op npmjs.com:

https://www.npmjs.com/search?q=keywords%3Aexpertteam-digitale-toegankelijkheid