### PR TITLE
Setup: Validate document instead of prosemirror

### DIFF
--- a/packages/editor/src/types/validation.ts
+++ b/packages/editor/src/types/validation.ts
@@ -1,12 +1,11 @@
-import type { Editor } from '@tiptap/core';
 import type { Node } from 'prosemirror-model';
 import type { EditorSettings } from '@/types/settings.ts';
 
 export type BoundingBox = { top: number; height: number };
 
-export type DocumentValidator = (editor: Editor, settings: EditorSettings) => ValidationResult[];
+export type DocumentValidator = (document: HTMLElement, settings: EditorSettings) => ValidationResult[];
 
-export type ContentValidator = (editor: Editor, node: Node, pos: number) => ValidationResult | null;
+export type ContentValidator = (document: HTMLElement, node: Node, pos: number) => ValidationResult | null;
 
 export type ValidationEntry = readonly [key: string, value: ValidationResult];
 

--- a/packages/editor/src/validators/content/index.ts
+++ b/packages/editor/src/validators/content/index.ts
@@ -126,16 +126,16 @@ const contentValidatorMap: { [K in ContentValidationKey]: ContentValidator } = {
   [contentValidations.NODE_SHOULD_NOT_BE_EMPTY]: nodeShouldNotBeEmpty,
 };
 
-const contentValidator = (editor: Editor) => {
+const contentValidator = (document: HTMLElement) => {
   const errors: Map<string, ValidationResult> = new Map();
-  editor.$doc.node.descendants((node, pos) => {
-    for (const [key, validator] of Object.entries(contentValidatorMap)) {
-      const result = validator(editor, node, pos);
-      if (result) {
-        errors.set(`${key}_${pos}`, result);
-      }
-    }
-  });
+  // editor.$doc.node.descendants((node, pos) => {
+  //   for (const [key, validator] of Object.entries(contentValidatorMap)) {
+  //     const result = validator(editor, node, pos);
+  //     if (result) {
+  //       errors.set(`${key}_${pos}`, result);
+  //     }
+  //   }
+  // });
   return errors;
 };
 

--- a/packages/editor/src/validators/document/index.ts
+++ b/packages/editor/src/validators/document/index.ts
@@ -7,23 +7,21 @@ import { getNodeBoundingBox, isBold } from '@/validators/helpers.ts';
 
 const documentValidators = new Map<string, DocumentValidator>();
 
-export const documentMustHaveCorrectHeadingOrder = (editor: Editor): ValidationResult[] => {
+export const documentMustHaveCorrectHeadingOrder = (document: HTMLElement): ValidationResult[] => {
   const errors: ValidationResult[] = [];
   let precedingHeadingLevel = 0;
-
-  editor.$doc.node.descendants((node, pos) => {
-    if (node.type.name === 'heading') {
-      const headingLevel = node.attrs['level'];
-      if (headingLevel > precedingHeadingLevel + 1) {
-        errors.push({
-          boundingBox: getNodeBoundingBox(editor, pos),
-          pos,
-          severity: validationSeverity.WARNING,
-          tipPayload: { headingLevel: headingLevel, precedingHeadingLevel: precedingHeadingLevel },
-        });
-      }
-      precedingHeadingLevel = headingLevel;
+  const headings = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+  headings.forEach((heading) => {
+    const headingLevel = Number.parseInt(heading.tagName.substring(1), 10);
+    if (headingLevel > precedingHeadingLevel + 1) {
+      errors.push({
+        boundingBox: getNodeBoundingBox(heading),
+        pos: 0,
+        severity: validationSeverity.WARNING,
+        tipPayload: { headingLevel: headingLevel, precedingHeadingLevel: precedingHeadingLevel },
+      });
     }
+    precedingHeadingLevel = headingLevel;
   });
   return errors;
 };
@@ -148,10 +146,10 @@ type DocumentValidationKey = (typeof documentValidations)[keyof typeof documentV
 
 const documentValidatorMap: { [K in DocumentValidationKey]: DocumentValidator } = {
   [documentValidations.DOCUMENT_MUST_HAVE_CORRECT_HEADING_ORDER]: documentMustHaveCorrectHeadingOrder,
-  [documentValidations.DOCUMENT_MUST_HAVE_SEMANTIC_LISTS]: documentMustHaveSemanticLists,
-  [documentValidations.DOCUMENT_MUST_HAVE_TOP_LEVEL_HEADING]: documentMustHaveTopLevelHeading,
-  [documentValidations.DOCUMENT_SHOULD_NOT_HAVE_HEADING_RESEMBLING_PARAGRAPHS]:
-    documentShouldNotHaveHeadingResemblingParagraphs,
+  //[documentValidations.DOCUMENT_MUST_HAVE_SEMANTIC_LISTS]: documentMustHaveSemanticLists,
+  //[documentValidations.DOCUMENT_MUST_HAVE_TOP_LEVEL_HEADING]: documentMustHaveTopLevelHeading,
+  //[documentValidations.DOCUMENT_SHOULD_NOT_HAVE_HEADING_RESEMBLING_PARAGRAPHS]:
+  //documentShouldNotHaveHeadingResemblingParagraphs,
 };
 
 for (const [key, validator] of Object.entries(documentValidatorMap)) {

--- a/packages/editor/src/validators/helpers.ts
+++ b/packages/editor/src/validators/helpers.ts
@@ -1,22 +1,10 @@
-import type { Editor } from '@tiptap/core';
 import type { Mark } from 'prosemirror-model';
 
-export const getNodeBoundingBox = (editor: Editor, pos: number): { top: number; height: number } | null => {
-  const domNode = editor.view.nodeDOM(pos);
-  if (domNode instanceof HTMLElement) {
-    return { height: domNode.offsetHeight, top: domNode.offsetTop };
-  }
-
-  if (domNode instanceof Text) {
-    const range = document.createRange();
-    range.selectNodeContents(domNode);
-    const rect = range.getBoundingClientRect();
-    const editorRect = editor.view.dom.getBoundingClientRect();
-
-    return {
-      height: rect.height,
-      top: rect.top - editorRect.top + editor.view.dom.scrollTop,
-    };
+export const getNodeBoundingBox = (element: Element): { top: number; height: number } | null => {
+  if (element instanceof HTMLElement) {
+    console.log(element.getBoundingClientRect());
+    // TODO: Detached DOM does not provide offsetTop/offsetHeight. Use TipTap anyway?
+    return { height: element.offsetHeight, top: element.offsetTop };
   }
 
   return null;

--- a/packages/editor/src/validators/index.ts
+++ b/packages/editor/src/validators/index.ts
@@ -13,10 +13,11 @@ export const runValidation = (
   callback: (resultMap: Map<string, ValidationResult>) => void,
 ) => {
   let validationResultMap = new Map<string, ValidationResult>();
+  const document = editor.view.dom;
 
   for (const [key, validator] of documentValidators.entries()) {
     try {
-      const result = validator(editor, settings);
+      const result = validator(document, settings);
       if (result.length > 0) {
         for (const res of result) {
           validationResultMap.set(`${key}_${res.pos}`, res);
@@ -28,7 +29,7 @@ export const runValidation = (
   }
 
   try {
-    const contentValidationResultMap = contentValidator(editor);
+    const contentValidationResultMap = contentValidator(document);
     if (contentValidationResultMap.size > 0) {
       validationResultMap = new Map<string, ValidationResult>([...validationResultMap, ...contentValidationResultMap]);
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,10 +189,10 @@ importers:
         version: 8.2.1
       '@vitest/browser-playwright':
         specifier: 4.0.14
-        version: 4.0.14(playwright@1.57.0)(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))(vitest@4.0.14)
+        version: 4.0.14(playwright@1.57.0)(vite@7.2.2(@types/node@22.19.1))(vitest@4.0.14)
       '@vitest/coverage-v8':
         specifier: 4.0.14
-        version: 4.0.14(@vitest/browser@4.0.14(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))(vitest@4.0.14))(vitest@4.0.14)
+        version: 4.0.14(@vitest/browser@4.0.14(vite@7.2.2(@types/node@22.19.1))(vitest@4.0.14))(vitest@4.0.14)
       cross-env:
         specifier: 10.1.0
         version: 10.1.0
@@ -204,7 +204,7 @@ importers:
         version: 1.57.0
       postcss-lit:
         specifier: 1.3.1
-        version: 1.3.1(postcss@8.5.6)(yaml@2.8.1)
+        version: 1.3.1(postcss@8.5.6)
       query-selector-shadow-dom:
         specifier: 1.0.1
         version: 1.0.1
@@ -213,13 +213,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.2.2
-        version: 7.2.2(@types/node@22.19.1)(yaml@2.8.1)
+        version: 7.2.2(@types/node@22.19.1)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@22.19.1)(rollup@4.53.2)(typescript@5.9.3)(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))
+        version: 4.5.4(@types/node@22.19.1)(rollup@4.53.2)(typescript@5.9.3)(vite@7.2.2(@types/node@22.19.1))
       vitest:
         specifier: 4.0.14
-        version: 4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14)(yaml@2.8.1)
+        version: 4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14)
 
   packages/editor-website:
     dependencies:
@@ -6077,29 +6077,29 @@ snapshots:
 
   '@utrecht/youtube-video-css@2.0.1': {}
 
-  '@vitest/browser-playwright@4.0.14(playwright@1.57.0)(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))(vitest@4.0.14)':
+  '@vitest/browser-playwright@4.0.14(playwright@1.57.0)(vite@7.2.2(@types/node@22.19.1))(vitest@4.0.14)':
     dependencies:
-      '@vitest/browser': 4.0.14(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))(vitest@4.0.14)
-      '@vitest/mocker': 4.0.14(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))
+      '@vitest/browser': 4.0.14(vite@7.2.2(@types/node@22.19.1))(vitest@4.0.14)
+      '@vitest/mocker': 4.0.14(vite@7.2.2(@types/node@22.19.1))
       playwright: 1.57.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14)(yaml@2.8.1)
+      vitest: 4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.14(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))(vitest@4.0.14)':
+  '@vitest/browser@4.0.14(vite@7.2.2(@types/node@22.19.1))(vitest@4.0.14)':
     dependencies:
-      '@vitest/mocker': 4.0.14(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.14(vite@7.2.2(@types/node@22.19.1))
       '@vitest/utils': 4.0.14
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14)(yaml@2.8.1)
+      vitest: 4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -6107,7 +6107,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.14(@vitest/browser@4.0.14(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))(vitest@4.0.14))(vitest@4.0.14)':
+  '@vitest/coverage-v8@4.0.14(@vitest/browser@4.0.14(vite@7.2.2(@types/node@22.19.1))(vitest@4.0.14))(vitest@4.0.14)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.14
@@ -6120,9 +6120,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14)(yaml@2.8.1)
+      vitest: 4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14)
     optionalDependencies:
-      '@vitest/browser': 4.0.14(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))(vitest@4.0.14)
+      '@vitest/browser': 4.0.14(vite@7.2.2(@types/node@22.19.1))(vitest@4.0.14)
     transitivePeerDependencies:
       - supports-color
 
@@ -6135,13 +6135,13 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.14(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.14(vite@7.2.2(@types/node@22.19.1))':
     dependencies:
       '@vitest/spy': 4.0.14
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.2(@types/node@22.19.1)(yaml@2.8.1)
+      vite: 7.2.2(@types/node@22.19.1)
 
   '@vitest/pretty-format@4.0.14':
     dependencies:
@@ -8283,26 +8283,25 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-lit@1.3.1(postcss@8.5.6)(yaml@2.8.1):
+  postcss-lit@1.3.1(postcss@8.5.6):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.4
       '@babel/traverse': 7.28.5
       lilconfig: 3.1.3
       postcss: 8.5.6
-      postcss-load-config: 6.0.1(postcss@8.5.6)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(postcss@8.5.6)
     transitivePeerDependencies:
       - jiti
       - supports-color
       - tsx
       - yaml
 
-  postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.1):
+  postcss-load-config@6.0.1(postcss@8.5.6):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.6
-      yaml: 2.8.1
 
   postcss-media-query-parser@0.2.3: {}
 
@@ -9218,7 +9217,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-dts@4.5.4(@types/node@22.19.1)(rollup@4.53.2)(typescript@5.9.3)(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1)):
+  vite-plugin-dts@4.5.4(@types/node@22.19.1)(rollup@4.53.2)(typescript@5.9.3)(vite@7.2.2(@types/node@22.19.1)):
     dependencies:
       '@microsoft/api-extractor': 7.53.1(@types/node@22.19.1)
       '@rollup/pluginutils': 5.3.0(rollup@4.53.2)
@@ -9231,7 +9230,7 @@ snapshots:
       magic-string: 0.30.19
       typescript: 5.9.3
     optionalDependencies:
-      vite: 7.2.2(@types/node@22.19.1)(yaml@2.8.1)
+      vite: 7.2.2(@types/node@22.19.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -9250,7 +9249,7 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.8.1
 
-  vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1):
+  vite@7.2.2(@types/node@22.19.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9261,12 +9260,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.1
       fsevents: 2.3.3
-      yaml: 2.8.1
 
-  vitest@4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14)(yaml@2.8.1):
+  vitest@4.0.14(@types/node@22.19.1)(@vitest/browser-playwright@4.0.14):
     dependencies:
       '@vitest/expect': 4.0.14
-      '@vitest/mocker': 4.0.14(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.14(vite@7.2.2(@types/node@22.19.1))
       '@vitest/pretty-format': 4.0.14
       '@vitest/runner': 4.0.14
       '@vitest/snapshot': 4.0.14
@@ -9283,11 +9281,11 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.2.2(@types/node@22.19.1)(yaml@2.8.1)
+      vite: 7.2.2(@types/node@22.19.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.1
-      '@vitest/browser-playwright': 4.0.14(playwright@1.57.0)(vite@7.2.2(@types/node@22.19.1)(yaml@2.8.1))(vitest@4.0.14)
+      '@vitest/browser-playwright': 4.0.14(playwright@1.57.0)(vite@7.2.2(@types/node@22.19.1))(vitest@4.0.14)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
Ik valideer zo `editor.view.dom` i.p.v. de editor instance. Ik had eerst een poging met editor.getHTML(), parseFromString, etc. Qua validatie is dat prima, maar de offsetHeight/getBoundingClientRect die kan je dan niet meer gebruiken.

Als de validaties ooit naar een service worker gaan, dan is het wellicht wel weer handig om niet direct de dom aan te spreken...

Misschien even over sparren, @Robbert ?