### PR TITLE
chore: accessibility improvements

### DIFF
--- a/packages/editor-website/e2e/page.spec.ts
+++ b/packages/editor-website/e2e/page.spec.ts
@@ -5,7 +5,7 @@ test('Page has correct title', async ({ page }) => {
 
   await expect(page).toHaveTitle('Rich-text Editor - NL Design System');
   await page.getByRole('paragraph').filter({ hasText: /^$/ }).fill('Paragraaf.');
-  const a11yButton = page.getByRole('button', { name: 'Toon toegankelijkheidsfouten' });
+  const a11yButton = page.getByRole('button', { name: 'Toon toegankelijkheidsmeldingen' });
   await expect(page.locator('data .nl-number-badge__visible-label')).toHaveText('3');
   await a11yButton.click();
   await page.waitForTimeout(500);

--- a/packages/editor/src/components/toolbar/index.test.ts
+++ b/packages/editor/src/components/toolbar/index.test.ts
@@ -20,19 +20,19 @@ describe('<clippy-toolbar>', () => {
 
   it('renders correctly with required toolbar elements', async () => {
     expect(page.getByLabelText('Werkbalk tekstbewerker')).toBeInTheDocument();
-    expect(page.getByLabelText('Bold')).toBeInTheDocument();
-    expect(page.getByLabelText('Italic')).toBeInTheDocument();
+    expect(page.getByLabelText('Vet')).toBeInTheDocument();
+    expect(page.getByLabelText('Cursief')).toBeInTheDocument();
     expect(page.getByLabelText('Link', { exact: true })).toBeInTheDocument();
   });
 
   it('updates all toolbar buttons when editor content changes', async () => {
-    expect(page.getByLabelText('Bold')).toHaveAttribute('aria-pressed', 'false');
+    expect(page.getByLabelText('Vet')).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('opens shortcuts dialog when keyboard shortcuts button is clicked', async () => {
     expect(page.getByTestId('clippy-shortcuts-dialog')).not.toHaveAttribute('open');
 
-    const button = page.getByRole('button', { name: 'Keyboard shortcuts' });
+    const button = page.getByRole('button', { name: 'Sneltoetsen' });
     await button.click();
     expect(page.getByTestId('clippy-shortcuts-dialog')).toHaveAttribute('open');
   });

--- a/packages/editor/src/components/toolbar/index.ts
+++ b/packages/editor/src/components/toolbar/index.ts
@@ -82,7 +82,7 @@ export class Toolbar extends LitElement {
       <div class="clippy-toolbar__wrapper" aria-label="Werkbalk tekstbewerker">
         <clippy-format-select></clippy-format-select>
         <clippy-toolbar-button
-          label="Bold"
+          label="Vet"
           .pressed=${this.editor?.isActive('bold') ?? false}
           @click=${() => this.editor?.chain().focus().toggleBold().run()}
           ${ref(this.#focusNode)}
@@ -90,14 +90,14 @@ export class Toolbar extends LitElement {
           ${unsafeSVG(addAriaHidden(BoldIcon))}
         </clippy-toolbar-button>
         <clippy-toolbar-button
-          label="Italic"
+          label="Cursief"
           .pressed=${this.editor?.isActive('italic') ?? false}
           @click=${() => this.editor?.chain().focus().toggleItalic().run()}
         >
           ${unsafeSVG(addAriaHidden(ItalicIcon))}
         </clippy-toolbar-button>
         <clippy-toolbar-button
-          label="Underline"
+          label="Onderstrepen"
           .pressed=${this.editor?.isActive('underline') ?? false}
           @click=${() => this.editor?.chain().focus().toggleUnderline().run()}
         >
@@ -105,21 +105,22 @@ export class Toolbar extends LitElement {
         </clippy-toolbar-button>
         <div class="clippy-toolbar__divider"></div>
         <clippy-toolbar-button
-          label="Undo"
+          label="Ongedaan maken"
           ?disabled=${!(this.editor?.can().undo() ?? false)}
           @click=${() => this.editor?.commands.undo()}
         >
           ${unsafeSVG(addAriaHidden(ArrowBackUpIcon))}
         </clippy-toolbar-button>
         <clippy-toolbar-button
-          label="Redo"
+          label="Opnieuw"
           ?disabled=${!(this.editor?.can().redo() ?? false)}
           @click=${() => this.editor?.commands.redo()}
-          >${unsafeSVG(addAriaHidden(ArrowForwardUpIcon))}
+        >
+          ${unsafeSVG(addAriaHidden(ArrowForwardUpIcon))}
         </clippy-toolbar-button>
         <div class="clippy-toolbar__divider"></div>
         <clippy-toolbar-button
-          label="Ordered list"
+          label="Genummerde lijst"
           .pressed=${this.editor?.isActive('orderedList') ?? false}
           @click=${() => {
             this.editor?.chain().focus().toggleOrderedList().run();
@@ -128,14 +129,14 @@ export class Toolbar extends LitElement {
           ${unsafeSVG(addAriaHidden(OrderedListIcon))}
         </clippy-toolbar-button>
         <clippy-toolbar-button
-          label="Bullet list"
+          label="Geordende lijst"
           .pressed=${this.editor?.isActive('bulletList') ?? false}
           @click=${() => this.editor?.chain().focus().toggleBulletList().run()}
         >
           ${unsafeSVG(addAriaHidden(BulletListIcon))}
         </clippy-toolbar-button>
         <clippy-toolbar-button
-          label="Definition list"
+          label="Definitielijst"
           .pressed=${this.editor?.isActive('definitionList') ?? false}
           @click=${() => this.editor?.chain().focus().insertDefinitionList().run()}
         >
@@ -155,19 +156,19 @@ export class Toolbar extends LitElement {
         <clippy-toolbar-image-upload></clippy-toolbar-image-upload>
         <div class="clippy-toolbar__divider"></div>
         <clippy-toolbar-button
-          label="Keyboard shortcuts"
+          label="Sneltoetsen"
           .pressed=${this.#dialogRef.value?.open ?? false}
           @click=${this.#toggleOpenShortcuts}
         >
           ${unsafeSVG(addAriaHidden(KeyboardIcon))}
         </clippy-toolbar-button>
         <clippy-toolbar-button
-          label="Toon toegankelijkheidsfouten"
+          label="Toon toegankelijkheidsmeldingen"
           class="clippy-dialog-toggle"
           @click=${this.#toggleOpenValidationsDialog}
           aria-controls="dialog-content"
         >
-          <span class="clippy-screen-reader-text">Toon toegankelijkheidsfouten</span>
+          <span class="clippy-screen-reader-text">Toon toegankelijkheidsmeldingen</span>
           ${unsafeSVG(AccessibleIcon)}
           ${
             size > 0
@@ -181,7 +182,7 @@ export class Toolbar extends LitElement {
       </div>
       <clippy-shortcuts .dialogRef=${this.#dialogRef}></clippy-shortcuts>
       <div class="clippy-screen-reader-text" aria-live=${size > 0 ? 'polite' : 'off'}>
-        Totaal ${size} gevonden toegankelijkheidsfouten.
+        Totaal ${size} toegankelijkheidsmeldingen gevonden.
       </div>
     `;
   }

--- a/packages/editor/src/components/toolbar/shortcuts-dialog/index.ts
+++ b/packages/editor/src/components/toolbar/shortcuts-dialog/index.ts
@@ -1,17 +1,18 @@
+import buttonCss from '@nl-design-system-candidate/button-css/button.css?inline';
 import CrossIcon from '@tabler/icons/outline/x.svg?raw';
-import { LitElement, html } from 'lit';
+import { LitElement, html, unsafeCSS } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ref, type Ref } from 'lit/directives/ref.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
-import shortcutsDialogStyles from './styles.ts';
 import './../toolbar-button';
+import shortcutsDialogStyles from './styles.ts';
 
 @customElement('clippy-shortcuts')
 export class ShortcutsDialog extends LitElement {
   @property({ attribute: false })
   public dialogRef?: Ref<HTMLDialogElement>;
 
-  static override readonly styles = [shortcutsDialogStyles];
+  static override readonly styles = [shortcutsDialogStyles, unsafeCSS(buttonCss)];
 
   public close(): void {
     this.dialogRef?.value?.close();
@@ -29,9 +30,10 @@ export class ShortcutsDialog extends LitElement {
       >
         <div class="clippy-shortcuts__header">
           <h1 id="clippy-shortcuts-title">Sneltoetsen</h1>
-          <clippy-toolbar-button @click=${() => this.close()} aria-label="Sluit sneltoetsen dialog">
+          <button class="nl-button nl-button--subtle nl-button--icon-only" @click=${() => this.close()}>
+            <span class="nl-button__label">Sluit sneltoetsen dialog</span>
             ${unsafeSVG(CrossIcon)}
-          </clippy-toolbar-button>
+          </button>
         </div>
         <table class="clippy-shortcuts__table">
           <caption>
@@ -140,7 +142,7 @@ export class ShortcutsDialog extends LitElement {
           </thead>
           <tbody>
           <tr>
-            <td>Toegankelijkheidsfouten</td>
+            <td>Toegankelijkheidsmeldingen</td>
             <td><kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd></td>
             <td><kbd>Command</kbd> + <kbd>Option</kbd> + <kbd>T</kbd></td>
           </tr>

--- a/packages/editor/src/components/validations/drawer/index.test.ts
+++ b/packages/editor/src/components/validations/drawer/index.test.ts
@@ -99,6 +99,6 @@ describe('<clippy-validations-dialog>', () => {
 
     // Verify first validation item has correct attributes
     const firstItem = validationItems?.[0];
-    expect(firstItem?.shadowRoot?.querySelector('strong')?.innerText).toBe('Koptekst mag niet leeg zijn');
+    expect(firstItem?.shadowRoot?.querySelector('h3')?.innerText).toBe('Koptekst mag niet leeg zijn');
   });
 });

--- a/packages/editor/src/components/validations/drawer/index.ts
+++ b/packages/editor/src/components/validations/drawer/index.ts
@@ -119,7 +119,7 @@ export class ValidationsDialog extends LitElement {
         ${ref(this.#dialogRef)}
         data-testid="clippy-validations-drawer"
         class="clippy-dialog__content"
-        aria-label="Toegankelijkheidsfouten"
+        aria-label="Toegankelijkheidsmeldingen"
       >
         <button class="clippy-dialog__close-button" @click=${() => this.#toggleOpen()}>${unsafeSVG(X)}</button>
         <clippy-tabs></clippy-tabs>
@@ -141,7 +141,7 @@ export class ValidationsDialog extends LitElement {
                   </clippy-validation-item>
                 `;
               })
-            : html`<li class="clippy-dialog__list-item">Geen toegankelijkheidsfouten gevonden.</li>`}
+            : html`<li class="clippy-dialog__list-item">Geen toegankelijkheidsmeldingen gevonden.</li>`}
         </ul>
       </dialog>
     `;

--- a/packages/editor/src/components/validations/validation-item/index.ts
+++ b/packages/editor/src/components/validations/validation-item/index.ts
@@ -18,6 +18,8 @@ declare global {
   }
 }
 
+const ariaDescribedBy = 'validation-item-header';
+
 @customElement(tag)
 export class ValidationItem extends LitElement {
   static override readonly styles = [validationListItemStyles, unsafeCSS(linkCss), unsafeCSS(buttonCss)];
@@ -53,7 +55,7 @@ export class ValidationItem extends LitElement {
         tabindex="-1"
       >
         <div class="clippy-dialog__list-item-message">
-          <strong>${this.description}</strong>
+          <h3 id=${ariaDescribedBy}>${this.description}</h3>
           <span class="clippy-dialog__list-item-severity clippy-dialog__list-item-severity--${this.severity}">
             ${unsafeSVG(this.#getAlertIcon())}
           </span>
@@ -62,13 +64,17 @@ export class ValidationItem extends LitElement {
         ${this.href
           ? html`
               <div class="clippy-dialog__list-item-link">
-                <a class="nl-link" href="${this.href}" target="_blank"> Uitgebreide toelichting </a>
+                <a class="nl-link" href="${this.href}" target="_blank" aria-describedby=${ariaDescribedBy}>
+                  Uitgebreide toelichting
+                </a>
               </div>
             `
           : null}
         <div class="clippy-dialog__list-item-actions">
           <button class="nl-button nl-button--disabled" aria-disabled="true">Negeren</button>
-          <button class="nl-button nl-button--secondary" @click=${this.#focusNode}>Aanpassen</button>
+          <button class="nl-button nl-button--secondary" @click=${this.#focusNode} aria-describedby=${ariaDescribedBy}>
+            Aanpassen
+          </button>
         </div>
       </li>
     `;

--- a/packages/editor/src/index.test.ts
+++ b/packages/editor/src/index.test.ts
@@ -17,7 +17,7 @@ describe('<clippy-editor>', () => {
   it('should change selected text to heading level 3', async () => {
     await expect(page.getByRole('heading', { name: 'Start met kopniveau 1' })).toBeInTheDocument();
 
-    const boldButton = page.getByRole('button', { name: 'Bold' }).element();
+    const boldButton = page.getByRole('button', { name: 'Vet' }).element();
 
     expect(boldButton).toBeInTheDocument();
     await user.click(boldButton);
@@ -43,7 +43,7 @@ describe('<clippy-editor>', () => {
   it('should open the shortcuts dialog with Command/Control + Alt + T', async () => {
     const text = page.getByText('Start met kopniveau 1').element();
     expect(text).toBeInTheDocument();
-    expect(page.getByLabelText('Toegankelijkheidsfouten', { exact: true })).not.toHaveAttribute('open');
+    expect(page.getByLabelText('Toegankelijkheidsmeldingen', { exact: true })).not.toHaveAttribute('open');
     await user.click(text);
     if (isMacOS()) {
       await user.keyboard('{meta>}{alt>}{t}{/alt}{/meta}');
@@ -53,25 +53,25 @@ describe('<clippy-editor>', () => {
     const a11yDialog = page.getByRole('dialog').element();
     expect(a11yDialog).toHaveAttribute('open');
 
-    expect(a11yDialog).toHaveTextContent('Geen toegankelijkheidsfouten gevonden.');
+    expect(a11yDialog).toHaveTextContent('Geen toegankelijkheidsmeldingen gevonden.');
   });
 
   it('all toolbar buttons are visible, regardless of viewport size', async () => {
-    expect(page.getByRole('button', { name: 'Bold' })).toBeVisible();
-    expect(page.getByRole('button', { name: 'Italic' })).toBeVisible();
-    expect(page.getByRole('button', { name: 'Underline' })).toBeVisible();
-    expect(page.getByRole('button', { name: 'Undo' })).toBeVisible();
-    expect(page.getByRole('button', { name: 'Redo' })).toBeVisible();
-    expect(page.getByRole('button', { name: 'Ordered list' })).toBeVisible();
-    expect(page.getByRole('button', { name: 'Bullet list' })).toBeVisible();
-    expect(page.getByRole('button', { name: 'Definition list' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Vet' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Cursief' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Onderstrepen' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Ongedaan maken' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Opnieuw' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Genummerde lijst' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Geordende lijst' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Definitielijst' })).toBeVisible();
     expect(page.getByRole('button', { name: 'Tabel invoegen' })).toBeVisible();
     const toolbar = await page.getByLabelText('Werkbalk tekstbewerker').element();
     await toolbar.querySelector('clippy-toolbar-link').updateComplete;
     await toolbar.querySelector('clippy-toolbar-image-upload').updateComplete;
     await expect(page.getByRole('button', { name: 'Link' })).toBeVisible();
     expect(page.getByRole('button', { name: 'Afbeelding' })).toBeVisible();
-    expect(page.getByRole('button', { name: 'Keyboard shortcuts' })).toBeVisible();
-    expect(page.getByRole('button', { name: 'Toon toegankelijkheidsfouten' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Sneltoetsen' })).toBeVisible();
+    expect(page.getByRole('button', { name: 'Toon toegankelijkheidsmeldingen' })).toBeVisible();
   });
 });


### PR DESCRIPTION
Feedback op toolbar buttons wordt nog verwerkt in de `clippy-button` die er deze sprint aankomt.