### PR TITLE
chore: configure dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,31 +22,76 @@ updates:
       nl-design-system:
         applies-to: "version-updates"
         patterns:
+          - "@amsterdam/*"
+          - "@gemeente-denhaag/*"
+          - "@gemeente-rotterdam/*"
+          - "@nl-design-system/*"
           - "@nl-design-system-candidate/*"
-          - "@utrecht/*"
-      tiptap:
+          - "@nl-design-system-community/*"
+          - "@nl-design-system-unstable/*"
+          - "@nl-rvo/*"
+          - "@rijkshuisstijl-community/*"
+      react:
         applies-to: "version-updates"
         patterns:
-          - "@tiptap/*"
-          - "prosemirror-model"
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      astro:
+        applies-to: "version-updates"
+        patterns:
+          - "@astrojs/*"
+          - "astro"
       storybook:
         applies-to: "version-updates"
         patterns:
           - "@storybook/*"
           - "storybook"
-      vite:
+      docusaurus:
         applies-to: "version-updates"
         patterns:
-          - "@vitest/*"
+          - "@docusaurus/*"
+      i18next:
+        applies-to: "version-updates"
+        patterns:
+          - "i18next"
+          - "i18next-*"
+          - "react-i18next"
+      tiptap:
+        applies-to: "version-updates"
+        patterns:
+          - "@tiptap/*"
+          - "prosemirror-model"
+      build-toolchain:
+        applies-to: "version-updates"
+        patterns:
+          - "@babel/*"
+          - "@rollup/*"
+          - "@vitejs/*"
+          - "rollup"
           - "vite"
-          - "vite-plugin-dts"
-          - "vitest"
-      astro:
+          - "vite-*"
+      test-toolchain:
         applies-to: "version-updates"
         patterns:
-          - "astro"
-          - "@astrojs/*"
-      patch-and-minor-dependencies:
+          - "@testing-library/*"
+          - "@vitest/*"
+          - "jsdom"
+          - "vitest"
+      lint-toolchain:
+        applies-to: "version-updates"
+        patterns:
+          - "@eslint/*"
+          - "eslint"
+          - "husky"
+          - "lint-staged"
+          - "markdownlint-cli"
+          - "npm-package-json-lint"
+          - "prettier"
+          - "stylelint"
+          - "stylelint-*"
+      patch-and-minor-updates:
         applies-to: "version-updates"
         update-types:
           - "patch"


### PR DESCRIPTION
Configure dependabot groups so packages upgrades are grouped logically together. This helps to reduce the number of invididual PRs for major upgrades and makes the minor/patch update group smaller. Thus making it easier to review, test and merge.

The groups were taken from the example repository.  For this repo, I kept the tiptap group.  The vite group is replaced by a broader build-toolchain group.  Let me know if this doesn't work for you.  vitest was moved to a test-toolchain group.

Tested with: `pnpm dlx @bugron/validate-dependabot-yaml@0.3.3 .github/dependabot.yml`
