### PR TITLE
chore: move vercel configuration to vercel.json

### DIFF
--- a/packages/editor-website/vercel.json
+++ b/packages/editor-website/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "cd ../.. && pnpm run build",
+  "framework": null,
+  "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/*": false,
+      "gh-pages": false
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "version": 2,
-  "name": "editor",
-  "buildCommand": "pnpm run build",
-  "outputDirectory": "packages/editor-website/dist"
-}


### PR DESCRIPTION
This PR is part of an effort to have all vercel configuration in Terraform.  Some settings should "move with the code" and these will be kept in `vercel.json`.  And this file should live with the app/package that is being served.

In Terraform, the rootDirectory will have to be set accordingly.  Until that is applied, PR might fail.

I notice that in terraform, output directory is currently set to `packages/website/dist`.  It looks like this is wrong.  With the current change in this PR and in terraform, this will become `packages/editor-website/dist`.
