### PR TITLE
chore: configure prettier to format pnpm-workspace.yaml the same as pnpm CLI does

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,8 +18,6 @@ CHANGELOG.md
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
-# pnpm using `pnpm config` is particular about the formatting of its workspace file
-pnpm-workspace.yaml
 
 # Ignore generated files from Stencil
 components/components.d.ts
@@ -33,7 +31,6 @@ packages/web-components-stencil/www/
 .changeset/*.md
 # …but don't ignore .changeset/README.md
 !.changeset/README.md
-
 
 # Use `terraform fmt` to fix formatting issues in Terraform files
 *.tf

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -31,5 +31,12 @@ export default {
         parser: 'astro',
       },
     },
+    {
+      // match pnpm CLI-driven changes behavior
+      files: ['pnpm-workspace.yaml'],
+      options: {
+        singleQuote: true,
+      },
+    },
   ],
 };


### PR DESCRIPTION
For YAML files, we use double quotes for strings.  We make an exception for the `pnpm-workspace.yaml` file, because the pnpm CLI uses single quotes.
