### PR TITLE
feat: add dark color scheme support

### DIFF
--- a/packages/ckeditor-plugin/src/plugin/ClippyPlugin.ts
+++ b/packages/ckeditor-plugin/src/plugin/ClippyPlugin.ts
@@ -3,6 +3,7 @@ import {
   type CloseValidationsDrawerDetail,
   type ValidationsDrawer,
 } from '@nl-design-system-community/editor/accessibility-notifications';
+import { applyColorScheme } from '@nl-design-system-community/editor/color-scheme';
 import { EditorContentWrapper, EditorWrapper } from '@nl-design-system-community/editor/editor-wrapper';
 import {
   CustomEvents,
@@ -68,6 +69,8 @@ export class ClippyPlugin extends Plugin {
 
     // add theme token scoping for the drupal environment.
     this._editorEl.classList.add('ma-theme', 'clippy-theme', 'utrecht-theme');
+    // follow the user's preferred color scheme by toggling the dark modifier on this editor.
+    applyColorScheme(this._editorEl);
     adoptClippyStyles();
 
     const wrapper = document.createElement('clippy-editor-wrapper') as EditorWrapper;

--- a/packages/drupal-ckeditor-plugin/vite.config.ts
+++ b/packages/drupal-ckeditor-plugin/vite.config.ts
@@ -11,6 +11,7 @@ const packageRequire = createRequire(import.meta.url);
 const editorRequire = createRequire(resolve(import.meta.dirname, '../editor/package.json'));
 const TOKENS_CSS = [
   '@nl-design-system-community/ma-design-tokens/dist/theme.css',
+  '@nl-design-system-community/ma-design-tokens/dist/color-scheme-dark/theme.css',
   '@utrecht/design-tokens/dist/theme.css',
   '@nl-design-system-candidate/button-css/button.css',
 ];

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -20,6 +20,10 @@
       "types": "./dist/entries/accessibility-notifications.d.ts",
       "default": "./dist/accessibility-notifications.js"
     },
+    "./color-scheme": {
+      "types": "./dist/entries/color-scheme.d.ts",
+      "default": "./dist/color-scheme.js"
+    },
     "./content-classes": {
       "types": "./dist/entries/content-classes.d.ts",
       "default": "./dist/content-classes.js"

--- a/packages/editor/src/components/validations/drawer/styles.ts
+++ b/packages/editor/src/components/validations/drawer/styles.ts
@@ -42,6 +42,7 @@ export default css`
 
   .clippy-drawer__title {
     margin-block: var(--basis-space-none);
+    color: var(--basis-color-default-color-document);
     font-family: var(--nl-paragraph-font-family, inherit);
   }
 

--- a/packages/editor/src/entries/color-scheme.ts
+++ b/packages/editor/src/entries/color-scheme.ts
@@ -1,0 +1,1 @@
+export { applyColorScheme, DARK_COLOR_SCHEME_CLASS, DARK_COLOR_SCHEME_QUERY, THEME_CLASS } from '../utils/colorScheme';

--- a/packages/editor/src/main.ts
+++ b/packages/editor/src/main.ts
@@ -3,6 +3,11 @@ import '@fontsource/fira-sans/700.css';
 import '@fontsource/source-sans-pro/400.css';
 import '@fontsource/source-sans-pro/700.css';
 import '@nl-design-system-community/ma-design-tokens/dist/theme.css';
+import '@nl-design-system-community/ma-design-tokens/dist/color-scheme-dark/theme.css';
 import '@utrecht/design-tokens/dist/theme.css';
 import './index';
 import '../theme.css';
+import { applyColorScheme } from './utils/colorScheme';
+
+// Toggle the dark design tokens based on the user's preferred color scheme.
+applyColorScheme();

--- a/packages/editor/src/utils/colorScheme.ts
+++ b/packages/editor/src/utils/colorScheme.ts
@@ -1,0 +1,26 @@
+export const DARK_COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+export const THEME_CLASS = 'ma-theme';
+export const DARK_COLOR_SCHEME_CLASS = 'ma-theme--color-scheme-dark';
+
+/** Toggles the dark modifier class on `root` to match the given preference. */
+const syncColorScheme = (root: HTMLElement, matches: boolean): void => {
+  root.classList.toggle(DARK_COLOR_SCHEME_CLASS, matches);
+};
+
+/**
+ * Keeps the `ma-theme--color-scheme-dark` modifier class in sync with the
+ * user's preferred color scheme.
+ *
+ * @param root - Element to toggle the class on (defaults to the `.ma-theme` element).
+ * @returns The observed `MediaQueryList`.
+ */
+export const applyColorScheme = (
+  root: HTMLElement = document.querySelector<HTMLElement>(`.${THEME_CLASS}`) ?? document.documentElement,
+): MediaQueryList => {
+  const query = window.matchMedia(DARK_COLOR_SCHEME_QUERY);
+
+  syncColorScheme(root, query.matches);
+  query.addEventListener('change', (event) => syncColorScheme(root, event.matches));
+
+  return query;
+};

--- a/packages/editor/src/utils/colorScheme.ts
+++ b/packages/editor/src/utils/colorScheme.ts
@@ -12,11 +12,16 @@ const syncColorScheme = (root: HTMLElement, matches: boolean): void => {
  * user's preferred color scheme.
  *
  * @param root - Element to toggle the class on (defaults to the `.ma-theme` element).
- * @returns The observed `MediaQueryList`.
+ * @returns The observed `MediaQueryList`, or `undefined` in environments without
+ *   `matchMedia` (e.g. server-side rendering or jsdom).
  */
 export const applyColorScheme = (
   root: HTMLElement = document.querySelector<HTMLElement>(`.${THEME_CLASS}`) ?? document.documentElement,
-): MediaQueryList => {
+): MediaQueryList | undefined => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return undefined;
+  }
+
   const query = window.matchMedia(DARK_COLOR_SCHEME_QUERY);
 
   syncColorScheme(root, query.matches);

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     lib: {
       entry: {
         'accessibility-notifications': 'src/entries/accessibility-notifications.ts',
+        'color-scheme': 'src/entries/color-scheme.ts',
         'content-classes': 'src/entries/content-classes.ts',
         'editor-wrapper': 'src/entries/editor-wrapper.ts',
         gutter: 'src/entries/gutter.ts',


### PR DESCRIPTION
Might be nice to expose a util from the editor, although I doubt it should be it's responsibility. 

Adds dark-mode theming driven by `prefers-color-scheme`. 
- A new `applyColorScheme` utility toggles the `ma-theme--color-scheme-dark` modifier on the `.ma-theme` element (following media-query `change` events) and is a no-op where `matchMedia` is unavailable (SSR/jsdom); the editor demo entry (`main.ts`) imports the dark token stylesheet and calls it.
- The utility is exposed as a `./color-scheme` subpath export so the CKEditor plugin can apply it per editor element (`applyColorScheme(this._editorEl)` in `ClippyPlugin`)
- The Drupal bundle now ships the `color-scheme-dark/theme.css` from `ma-design-tokens`.