### PR TITLE
docs: document the Playwright integration on the integrations page

### DIFF
--- a/docs/en/playwright/playwright.md
+++ b/docs/en/playwright/playwright.md
@@ -1,0 +1,139 @@
+---
+title: Playwright integration
+intro: The Playwright integration audits published editor output in a real browser. The validator is injected into the page under test and runs against the live DOM, the same way @axe-core/playwright injects axe-core.
+---
+
+## Installation
+
+The integration ships inside the `@nl-design-system-community/clippy-a11y-validator` package, under
+the `/playwright` subpath. `@playwright/test` is a peer dependency, so you bring your own version
+(1.50 or higher).
+
+```bash
+npm install --save-dev @nl-design-system-community/clippy-a11y-validator @playwright/test
+```
+
+> **Not on npm yet:** the package has not been published. Inside this monorepo, depend on it with
+> `"@nl-design-system-community/clippy-a11y-validator": "workspace:*"`; the command above works once
+> the first version is released.
+
+## Quick start
+
+`ClippyBuilder` is a fluent API in the style of `AxeBuilder`. Pass it the Playwright `page`,
+optionally scope the region to audit, and call `validate()`.
+
+```ts
+import { test, expect } from '@playwright/test';
+import ClippyBuilder from '@nl-design-system-community/clippy-a11y-validator/playwright';
+
+test('editor output is accessible', async ({ page }) => {
+  await page.goto('http://localhost:5173/preview');
+
+  const results = await new ClippyBuilder({ page }).include('.clippy-content').validate();
+
+  expect(results.validationItems).toEqual([]);
+});
+```
+
+## The builder API
+
+Every configuration method returns the builder, so calls can be chained. `validate()` ends the chain
+and resolves to the report.
+
+```ts
+const results = await new ClippyBuilder({ page })
+  .include('.clippy-content') // audit only this region (default: document.body)
+  .enableRules(['image-must-have-alt-text']) // only these rules (default: all)
+  .disableRules(['paragraph-should-not-resemble-list']) // exclude rules
+  .settings({ topHeadingLevel: 2 }) // highest allowed starting heading level (default: 1)
+  .validate();
+```
+
+| Method                | Purpose                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `include(selector)`   | Scopes validation to the first element matching `selector`. Without `include`, `document.body` is audited. |
+| `enableRules(rules)`  | Limits validation to the given rules. Accepts kebab-case or SCREAMING_SNAKE_CASE.                          |
+| `disableRules(rules)` | Excludes the given rules.                                                                                  |
+| `settings(settings)`  | Non-rule settings, such as `topHeadingLevel`.                                                              |
+| `validate()`          | Injects the validator, runs it against the live DOM and returns a `ValidationReport`.                      |
+
+## The report
+
+`validate()` resolves to a `ValidationReport` holding a single `validationItems` array. Each item is
+grouped per rule and lists every place it applies, mirroring axe-core:
+
+```ts
+{
+  id: 'heading-must-not-be-empty',
+  severity: 'error',
+  description: 'Heading must not be empty',
+  href: 'https://nldesignsystem.nl/...',
+  nodes: [{ target: 'h1', html: '<h1></h1>' }],
+}
+```
+
+`severity` is `'error'`, `'warning'` or `'info'`. `target` is a CSS selector relative to the validated
+root, and `html` is the element's truncated `outerHTML`.
+
+## Reporting and failing the build
+
+The reporting helpers from the main package are re-exported from `/playwright` too, so a single import
+covers both running and reporting.
+
+```ts
+import ClippyBuilder, {
+  assertNoValidationItems,
+  countBySeverity,
+  formatValidationItems,
+  hasSeverityAtLeast,
+} from '@nl-design-system-community/clippy-a11y-validator/playwright';
+
+const results = await new ClippyBuilder({ page }).include('.clippy-content').validate();
+
+// A readable, terminal-friendly report.
+console.info(formatValidationItems(results));
+
+// Counts per severity, for example { error: 1, warning: 0, info: 2 }.
+countBySeverity(results);
+
+// True as soon as any item sits at or above this threshold.
+hasSeverityAtLeast(results, 'warning');
+
+// Throws with the formatted report as its message: the build gate.
+assertNoValidationItems(results, { failOn: 'error' });
+```
+
+`assertNoValidationItems` fails on `'error'` by default. Set `failOn` to `'warning'` or `'info'` to be
+stricter. Because the thrown message is the full report, the Playwright output shows exactly which
+elements caused the failure.
+
+## Playwright configuration
+
+When your specs fill the page with `page.setContent()`, no dev server is needed:
+
+```ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  reporter: 'list',
+  testDir: './tests',
+});
+```
+
+To audit a running application, use `webServer` and `use.baseURL` as you normally would with
+Playwright, and navigate with `page.goto()` to the page that renders the editor output.
+
+## How it works
+
+In Node, `validate()` reads the validator's dependency-free ESM bundle, injects it into the page as an
+object-URL module, and runs `ClippyValidator` against the scoped element in the browser. Because
+validation happens in the browser, the DOM as actually rendered is audited, including anything
+client-side scripts changed.
+
+> **Content Security Policy:** injection uses a `blob:` module. Pages that forbid `script-src blob:`
+> will block it. Audit such pages against a build served without that restriction, or via
+> `page.setContent()`.
+
+Since the validator itself carries no editor, ProseMirror or localisation dependencies, this
+integration can audit output that was not produced by the Clippy Editor at all.

--- a/docs/playwright/playwright.md
+++ b/docs/playwright/playwright.md
@@ -1,0 +1,139 @@
+---
+title: Playwright integratie
+intro: Met de Playwright-integratie controleer je de gepubliceerde editor-uitvoer in een echte browser. De validator wordt in de pagina geïnjecteerd en draait tegen de live DOM, op dezelfde manier waarop @axe-core/playwright axe-core injecteert.
+---
+
+## Installatie
+
+De integratie zit in het `@nl-design-system-community/clippy-a11y-validator` pakket, onder het
+`/playwright` subpad. `@playwright/test` is een peer dependency: je gebruikt je eigen versie
+(1.50 of hoger).
+
+```bash
+npm install --save-dev @nl-design-system-community/clippy-a11y-validator @playwright/test
+```
+
+> **Nog niet op npm:** het pakket is nog niet gepubliceerd. Binnen deze monorepo verwijs je ernaar met
+> `"@nl-design-system-community/clippy-a11y-validator": "workspace:*"`; het commando hierboven werkt
+> zodra de eerste versie is uitgebracht.
+
+## Snel starten
+
+`ClippyBuilder` is een fluent API in de stijl van `AxeBuilder`. Je geeft de Playwright `page` mee,
+bakent optioneel het te controleren gebied af, en roept `validate()` aan.
+
+```ts
+import { test, expect } from '@playwright/test';
+import ClippyBuilder from '@nl-design-system-community/clippy-a11y-validator/playwright';
+
+test('editor-uitvoer is toegankelijk', async ({ page }) => {
+  await page.goto('http://localhost:5173/preview');
+
+  const results = await new ClippyBuilder({ page }).include('.clippy-content').validate();
+
+  expect(results.validationItems).toEqual([]);
+});
+```
+
+## De builder API
+
+Alle instelmethoden geven de builder terug, dus je kunt ze aan elkaar rijgen. `validate()` sluit de
+keten af en levert het rapport op.
+
+```ts
+const results = await new ClippyBuilder({ page })
+  .include('.clippy-content') // beperk tot dit gebied (standaard: document.body)
+  .enableRules(['image-must-have-alt-text']) // alleen deze regels (standaard: alle)
+  .disableRules(['paragraph-should-not-resemble-list']) // sluit regels uit
+  .settings({ topHeadingLevel: 2 }) // hoogst toegestane startkopniveau (standaard: 1)
+  .validate();
+```
+
+| Methode               | Doel                                                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `include(selector)`   | Beperkt de validatie tot het eerste element dat op `selector` past. Zonder `include` wordt `document.body` gecontroleerd. |
+| `enableRules(rules)`  | Beperkt de validatie tot de opgegeven regels. Accepteert kebab-case of SCREAMING_SNAKE_CASE.                              |
+| `disableRules(rules)` | Sluit de opgegeven regels uit.                                                                                            |
+| `settings(settings)`  | Instellingen die geen regel zijn, zoals `topHeadingLevel`.                                                                |
+| `validate()`          | Injecteert de validator, draait deze tegen de live DOM en geeft een `ValidationReport`.                                   |
+
+## Het rapport
+
+`validate()` geeft een `ValidationReport` met één `validationItems` array. Elk item is gegroepeerd per
+regel en somt de gevonden plekken op, net als bij axe-core:
+
+```ts
+{
+  id: 'heading-must-not-be-empty',
+  severity: 'error',
+  description: 'Heading must not be empty',
+  href: 'https://nldesignsystem.nl/...',
+  nodes: [{ target: 'h1', html: '<h1></h1>' }],
+}
+```
+
+`severity` is `'error'`, `'warning'` of `'info'`. `target` is een CSS-selector ten opzichte van de
+gevalideerde root, `html` de afgekapte `outerHTML` van het element.
+
+## Rapporteren en de build afkeuren
+
+Dezelfde rapportage-helpers uit het hoofdpakket worden ook vanuit `/playwright` geëxporteerd, dus één
+import dekt zowel het draaien als het rapporteren.
+
+```ts
+import ClippyBuilder, {
+  assertNoValidationItems,
+  countBySeverity,
+  formatValidationItems,
+  hasSeverityAtLeast,
+} from '@nl-design-system-community/clippy-a11y-validator/playwright';
+
+const results = await new ClippyBuilder({ page }).include('.clippy-content').validate();
+
+// Leesbaar, terminal-vriendelijk overzicht.
+console.info(formatValidationItems(results));
+
+// Aantallen per severity, bijvoorbeeld { error: 1, warning: 0, info: 2 }.
+countBySeverity(results);
+
+// True zodra er een item op of boven deze drempel staat.
+hasSeverityAtLeast(results, 'warning');
+
+// Gooit een error met het opgemaakte rapport als bericht: de build-poort.
+assertNoValidationItems(results, { failOn: 'error' });
+```
+
+`assertNoValidationItems` faalt standaard op `'error'`. Zet `failOn` op `'warning'` of `'info'` om
+strenger te zijn. Omdat de foutmelding het volledige rapport is, staat in de Playwright-uitvoer
+direct welke elementen het probleem veroorzaken.
+
+## Playwright configuratie
+
+Als je specs de pagina met `page.setContent()` vullen is er geen dev-server nodig:
+
+```ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  reporter: 'list',
+  testDir: './tests',
+});
+```
+
+Controleer je een draaiende applicatie, gebruik dan `webServer` en `use.baseURL` zoals gebruikelijk
+bij Playwright, en navigeer met `page.goto()` naar de pagina die de editor-uitvoer rendert.
+
+## Hoe het werkt
+
+`validate()` leest in Node de dependency-vrije ESM-bundle van de validator, injecteert die als
+object-URL module in de pagina, en draait `ClippyValidator` tegen het afgebakende element in de
+browser. Omdat de validatie in de browser gebeurt, wordt de daadwerkelijk gerenderde DOM
+gecontroleerd, inclusief wat client-side scripts hebben aangepast.
+
+> **Content Security Policy:** de injectie gebruikt een `blob:` module. Pagina's die
+> `script-src blob:` verbieden blokkeren dit. Controleer zulke pagina's tegen een build die zonder
+> die restrictie wordt geserveerd, of via `page.setContent()`.
+
+Omdat de validator zelf geen editor-, ProseMirror- of localisatie-afhankelijkheden heeft, kun je met
+deze integratie ook uitvoer controleren die niet door de Clippy Editor is gemaakt.

--- a/packages/editor-website/src/i18n/translations.ts
+++ b/packages/editor-website/src/i18n/translations.ts
@@ -40,6 +40,7 @@ const translations = {
     'nav.language': 'Nederlands',
     'nav.language.label': 'Schakel naar Nederlands',
     'nav.react': 'React',
+    'playwright.title': 'Playwright integration - Rich-text Editor - NL Design System',
     'react.title': 'React integration - Rich-text Editor - NL Design System',
     'site.logo.label': 'NL Design System Editor – home',
 
@@ -88,6 +89,7 @@ const translations = {
     'nav.language': 'English',
     'nav.language.label': 'Switch to English',
     'nav.react': 'React',
+    'playwright.title': 'Playwright integratie - Rich-text Editor - NL Design System',
     'react.title': 'React integratie - Rich-text Editor - NL Design System',
     'site.logo.label': 'NL Design System Editor – home',
     'site.title': 'Rich-text Editor - NL Design System',

--- a/packages/editor-website/src/pages/en/integrations.astro
+++ b/packages/editor-website/src/pages/en/integrations.astro
@@ -30,6 +30,13 @@ const t = useTranslations('en');
             <code>@nl-design-system-community/ckeditor-plugin</code>.
           </p>
         </Card>
+
+        <Card heading="Playwright" href="/en/playwright">
+          <p>
+            Audit published editor output in a real browser. The validator is injected into the page and runs against
+            the live DOM, so accessibility failures are caught by your test suite.
+          </p>
+        </Card>
       </CardGroup>
     </Section>
   </main>

--- a/packages/editor-website/src/pages/en/playwright.astro
+++ b/packages/editor-website/src/pages/en/playwright.astro
@@ -1,0 +1,26 @@
+---
+import Document from '../../layouts/document.astro';
+import Hero from '../../components/Hero.astro';
+import Section from '../../components/Section.astro';
+import {
+  Content as PlaywrightContent,
+  frontmatter as playwrightFrontmatter,
+} from '../../../../../docs/en/playwright/playwright.md';
+import { useTranslations } from '../../i18n/translations.ts';
+
+const t = useTranslations('en');
+---
+
+<Document title={t('playwright.title')}>
+  <main>
+    <Hero title={playwrightFrontmatter['title']} intro={playwrightFrontmatter['intro']}>
+      <Fragment slot="badges">
+        <a href="https://github.com/nl-design-system/editor">
+          <img src="https://img.shields.io/badge/github-repo-blue?logo=github" alt="GitHub repository" />
+        </a>
+      </Fragment>
+    </Hero>
+
+    <Section content={PlaywrightContent} />
+  </main>
+</Document>

--- a/packages/editor-website/src/pages/integraties.astro
+++ b/packages/editor-website/src/pages/integraties.astro
@@ -30,6 +30,13 @@ const t = useTranslations('nl');
             <code>@nl-design-system-community/ckeditor-plugin</code>.
           </p>
         </Card>
+
+        <Card heading="Playwright" href="/playwright">
+          <p>
+            Controleer de gepubliceerde editor-uitvoer in een echte browser. De validator wordt in de pagina
+            geïnjecteerd en draait tegen de live DOM, zodat je toegankelijkheidsfouten in je testsuite afvangt.
+          </p>
+        </Card>
       </CardGroup>
     </Section>
   </main>

--- a/packages/editor-website/src/pages/playwright.astro
+++ b/packages/editor-website/src/pages/playwright.astro
@@ -1,0 +1,26 @@
+---
+import Document from '../layouts/document.astro';
+import Hero from '../components/Hero.astro';
+import Section from '../components/Section.astro';
+import {
+  Content as PlaywrightContent,
+  frontmatter as playwrightFrontmatter,
+} from '../../../../docs/playwright/playwright.md';
+import { useTranslations } from '../i18n/translations.ts';
+
+const t = useTranslations('nl');
+---
+
+<Document title={t('playwright.title')}>
+  <main>
+    <Hero title={playwrightFrontmatter['title']} intro={playwrightFrontmatter['intro']}>
+      <Fragment slot="badges">
+        <a href="https://github.com/nl-design-system/editor">
+          <img src="https://img.shields.io/badge/github-repo-blue?logo=github" alt="GitHub repository" />
+        </a>
+      </Fragment>
+    </Hero>
+
+    <Section content={PlaywrightContent} />
+  </main>
+</Document>


### PR DESCRIPTION
Documents the `clippy-a11y-validator` Playwright integration as a subpage of the integrations page, in both locales.

## What this adds

| File | Purpose |
| --- | --- |
| `docs/playwright/playwright.md` | Dutch content |
| `docs/en/playwright/playwright.md` | English content |
| `packages/editor-website/src/pages/playwright.astro` | `/playwright` |
| `packages/editor-website/src/pages/en/playwright.astro` | `/en/playwright` |
| `src/pages/integraties.astro`, `src/pages/en/integrations.astro` | Playwright card linking to the subpage |
| `src/i18n/translations.ts` | `playwright.title` in both locales |

Discovery follows the existing `/ckeditor` precedent: a `Card` on the integrations page rather than a top-level nav entry.

## Content

Installation, the `ClippyBuilder` chain (`include` / `enableRules` / `disableRules` / `settings` / `validate`), the `ValidationReport` shape, the reporting helpers as a CI gate (`formatValidationItems`, `assertNoValidationItems`, `countBySeverity`, `hasSeverityAtLeast`), a Playwright config example, and how injection works, including the `blob:` module CSP caveat.

## Verification

- `astro build` passes; all 16 pages build, including both new routes.
- Every documented snippet was extracted into a throwaway spec, type-checked against `tsconfig.test.json` and run under `playwright test` -- passes, so the documented API surface is real rather than paraphrased. The package's own suite (6 tests) also passes.
- `prettier --check` and `markdownlint` clean.
- No npm badge: `@nl-design-system-community/clippy-a11y-validator` is not published yet, so a version badge would render as not-found. The install section says so explicitly and gives the `workspace:*` route in the meantime.

## Base branch

Targets `feat/separate-clippy-validations-package`, not `main` -- the package being documented only exists on that branch.

> [!NOTE]
> That base is currently the **pre-rebase** version on origin, while this branch is built on the rebased one. The diff below therefore includes the 22 rebased commits as noise. It reduces to the 7 docs files once the base is force-pushed; nothing here depends on that happening first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
